### PR TITLE
Fetch PRs on webhooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "github-webhook-event-types": "^1.2.1",
     "graphql": "^14.6.0",
     "graphql-tag": "^2.10.3",
+    "lru_map": "^0.3.3",
     "parse-link-header": "^1.0.1",
     "rxjs": "^6.5.4",
     "source-map-support": "^0.5.16",

--- a/src/routes/webhook_route.ts
+++ b/src/routes/webhook_route.ts
@@ -65,12 +65,19 @@ export const webhookRoute = new Route('POST', '/webhook', async ctx => {
     switch (event) {
       case 'pull_request': {
         const wh = webhook as GithubWebhookPullRequestEvent
+        // fetch the current PR state, when PRs are first created
+        // we get a bunch of requests at once so we hope this will
+        // ensure PRs are in the correct state when we inspect them.
+        const pr = await githubApi.getPr(wh.pull_request.number, {
+          forceRetries: true,
+        })
+
         return {
           body: await runReactors(prReactors, {
             context: {
               input: {
                 action: wh.action,
-                pr: wh.pull_request,
+                pr,
               },
               githubApi,
               log,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3986,6 +3986,11 @@ lru-cache@^4.0.0:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"


### PR DESCRIPTION
There is a race condition that prevents us from being able to rely on the labels associated with a PR when we receive the "pr created" hook; when Github sends hooks for creating a PR it first sends the "created" hook with a PR that has no labels, and then subsequent hooks for each label added when the PR was created. This means that we might receive the "created" hook after the "labeled" hook, and the PR we see might have no labels, so we end up setting "missing labels" statuses on the PR.

I'm thinking we can avoid this issue by fetching the PR and using that instead of the copy of the PR sent with the webhook, but first we have to make sure that we can retry calls to `githubApi.getPr()` as the GET api sometimes responds with 404 even now.