### PR TITLE
Add missing/new kibana docs paths

### DIFF
--- a/src/lib/classify_changes.test.ts
+++ b/src/lib/classify_changes.test.ts
@@ -1,0 +1,34 @@
+import * as changes from './classify_changes'
+
+describe('classify_changes', () => {
+  describe('getIncludesDocsSiteChanges()', () => {
+    it('should return true for files that include docs changes', () => {
+      const testCases = [
+        ['docs/README'],
+        ['some/other/file', 'docs/help.asciidoc'],
+        ['x-pack/help.asciidoc'],
+        ['x-pack/something/help.asciidoc'],
+        ['src/something/help.asciidoc'],
+        ['examples/something/help.asciidoc'],
+      ]
+
+      for (const testCase of testCases) {
+        expect(changes.getIncludesDocsSiteChanges(testCase)).toBe(true)
+      }
+    })
+
+    it('should return false for files that do not include docs changes', () => {
+      const testCases = [
+        ['some/other/file'],
+        ['some/other/file', 'some/other/dir/help.asciidoc'],
+        ['x-pack/something/README.md'],
+        ['non-root/src/somewhere/something.asciidoc'],
+        ['non-root/examples/help.asciidoc'],
+      ]
+
+      for (const testCase of testCases) {
+        expect(changes.getIncludesDocsSiteChanges(testCase)).toBe(false)
+      }
+    })
+  })
+})

--- a/src/lib/classify_changes.ts
+++ b/src/lib/classify_changes.ts
@@ -18,7 +18,7 @@ const fileEndsWith = (f: File, endsWith: string) =>
 
 const isDocs = (f: File) =>
   fileStartsWith(f, 'docs/') ||
-  fileMatch(f, p => /^((x-pack)|(src)|(examples))\/.+\.asciidoc$/.test(p))
+  fileMatch(f, p => /^(x-pack|src|examples)\/.+\.asciidoc$/.test(p))
 const isRfc = (f: File) => fileStartsWith(f, 'rfcs/')
 const isApm = (f: File) => fileIncludes(f, '/apm/')
 const isMarkdown = (f: File) => fileEndsWith(f, '.md')

--- a/src/lib/classify_changes.ts
+++ b/src/lib/classify_changes.ts
@@ -16,7 +16,9 @@ const fileIncludes = (f: File, includes: string) =>
 const fileEndsWith = (f: File, endsWith: string) =>
   fileMatch(f, p => p.endsWith(endsWith))
 
-const isDocs = (f: File) => fileStartsWith(f, 'docs/')
+const isDocs = (f: File) =>
+  fileStartsWith(f, 'docs/') ||
+  fileMatch(f, p => /^((x-pack)|(src)|(examples))\/.+\.asciidoc$/.test(p))
 const isRfc = (f: File) => fileStartsWith(f, 'rfcs/')
 const isApm = (f: File) => fileIncludes(f, '/apm/')
 const isMarkdown = (f: File) => fileEndsWith(f, '.md')


### PR DESCRIPTION
These paths were added recently. A broken PR was allowed to be merged because the bot doesn't currently account for these paths.