### PR TITLE
Label Reactors for PRs and Issues

### DIFF
--- a/src/reactors/apply_label_transforms.test.ts
+++ b/src/reactors/apply_label_transforms.test.ts
@@ -1,0 +1,84 @@
+import { applyLabelTransforms } from './apply_label_transforms'
+
+it('calls the transform functions in order', () => {
+  const transforms = [
+    jest.fn().mockReturnValue(['bar', 'baz']),
+    jest.fn().mockReturnValue(['box', 'bot']),
+  ]
+
+  applyLabelTransforms(['foo', 'bar'], transforms)
+
+  expect(transforms).toMatchInlineSnapshot(`
+    Array [
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            Array [
+              "foo",
+              "bar",
+            ],
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": Array [
+              "bar",
+              "baz",
+            ],
+          },
+        ],
+      },
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            Array [
+              "bar",
+              "baz",
+            ],
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": Array [
+              "box",
+              "bot",
+            ],
+          },
+        ],
+      },
+    ]
+  `)
+})
+
+it('returns the new label list if label was added', () => {
+  expect(applyLabelTransforms(['foo', 'bar'], [l => [...l, 'baz']]))
+    .toMatchInlineSnapshot(`
+    Array [
+      "foo",
+      "bar",
+      "baz",
+    ]
+  `)
+})
+
+it('returns the new label list if a label was removed', () => {
+  expect(
+    applyLabelTransforms(
+      ['foo', 'bar', 'box'],
+      [labels => labels.filter(l => l.startsWith('b'))],
+    ),
+  ).toMatchInlineSnapshot(`
+    Array [
+      "bar",
+      "box",
+    ]
+  `)
+})
+
+it('returns null if the labels are unchanged', () => {
+  expect(
+    applyLabelTransforms(['foo', 'bar'], [labels => [...labels]]),
+  ).toMatchInlineSnapshot(`null`)
+})

--- a/src/reactors/apply_label_transforms.test.ts
+++ b/src/reactors/apply_label_transforms.test.ts
@@ -55,11 +55,17 @@ it('calls the transform functions in order', () => {
 it('returns the new label list if label was added', () => {
   expect(applyLabelTransforms(['foo', 'bar'], [l => [...l, 'baz']]))
     .toMatchInlineSnapshot(`
-    Array [
-      "foo",
-      "bar",
-      "baz",
-    ]
+    Object {
+      "added": Array [
+        "baz",
+      ],
+      "labels": Array [
+        "foo",
+        "bar",
+        "baz",
+      ],
+      "removed": Array [],
+    }
   `)
 })
 
@@ -70,10 +76,42 @@ it('returns the new label list if a label was removed', () => {
       [labels => labels.filter(l => l.startsWith('b'))],
     ),
   ).toMatchInlineSnapshot(`
-    Array [
-      "bar",
-      "box",
-    ]
+    Object {
+      "added": Array [],
+      "labels": Array [
+        "bar",
+        "box",
+      ],
+      "removed": Array [
+        "foo",
+      ],
+    }
+  `)
+})
+
+it('returns the new label list if a label was added and a label was removed', () => {
+  expect(
+    applyLabelTransforms(
+      ['foo', 'bar', 'box'],
+      [
+        labels => labels.filter(l => l.startsWith('b')),
+        labels => [...labels, 'zip'],
+      ],
+    ),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "added": Array [
+        "zip",
+      ],
+      "labels": Array [
+        "bar",
+        "box",
+        "zip",
+      ],
+      "removed": Array [
+        "foo",
+      ],
+    }
   `)
 })
 

--- a/src/reactors/apply_label_transforms.ts
+++ b/src/reactors/apply_label_transforms.ts
@@ -1,0 +1,17 @@
+export type LabelTransform = (labels: string[]) => string[]
+
+export const applyLabelTransforms = (
+  currentLabels: string[],
+  transforms: LabelTransform[],
+) => {
+  const labels = transforms.reduce((acc, transform) => transform(acc), [
+    ...currentLabels,
+  ])
+
+  const diff = [
+    ...labels.filter(label => !currentLabels.includes(label)),
+    ...currentLabels.filter(label => !labels.includes(label)),
+  ]
+
+  return diff.length ? labels : null
+}

--- a/src/reactors/apply_label_transforms.ts
+++ b/src/reactors/apply_label_transforms.ts
@@ -8,10 +8,8 @@ export const applyLabelTransforms = (
     ...currentLabels,
   ])
 
-  const diff = [
-    ...labels.filter(label => !currentLabels.includes(label)),
-    ...currentLabels.filter(label => !labels.includes(label)),
-  ]
+  const added = labels.filter(label => !currentLabels.includes(label))
+  const removed = currentLabels.filter(label => !labels.includes(label))
 
-  return diff.length ? labels : null
+  return added.length || removed.length ? { added, removed, labels } : null
 }

--- a/src/reactors/index.ts
+++ b/src/reactors/index.ts
@@ -4,3 +4,5 @@ export * from './run_reactors'
 export * from './status'
 export * from './issue'
 export * from './label'
+
+export type LabelTransform = (labels: string[]) => string[]

--- a/src/reactors/index.ts
+++ b/src/reactors/index.ts
@@ -6,3 +6,19 @@ export * from './issue'
 export * from './label'
 
 export type LabelTransform = (labels: string[]) => string[]
+
+export const performLabelTransform = (
+  currentLabels: string[],
+  transforms: LabelTransform[],
+) => {
+  const labels = transforms.reduce((acc, transform) => transform(acc), [
+    ...currentLabels,
+  ])
+
+  const diff = [
+    ...labels.filter(label => !currentLabels.includes(label)),
+    ...currentLabels.filter(label => !labels.includes(label)),
+  ]
+
+  return diff ? labels : null
+}

--- a/src/reactors/index.ts
+++ b/src/reactors/index.ts
@@ -20,5 +20,5 @@ export const performLabelTransform = (
     ...currentLabels.filter(label => !labels.includes(label)),
   ]
 
-  return diff ? labels : null
+  return diff.length ? labels : null
 }

--- a/src/reactors/index.ts
+++ b/src/reactors/index.ts
@@ -4,21 +4,3 @@ export * from './run_reactors'
 export * from './status'
 export * from './issue'
 export * from './label'
-
-export type LabelTransform = (labels: string[]) => string[]
-
-export const performLabelTransform = (
-  currentLabels: string[],
-  transforms: LabelTransform[],
-) => {
-  const labels = transforms.reduce((acc, transform) => transform(acc), [
-    ...currentLabels,
-  ])
-
-  const diff = [
-    ...labels.filter(label => !currentLabels.includes(label)),
-    ...currentLabels.filter(label => !labels.includes(label)),
-  ]
-
-  return diff.length ? labels : null
-}

--- a/src/reactors/issue/add_label_reactor.ts
+++ b/src/reactors/issue/add_label_reactor.ts
@@ -1,0 +1,48 @@
+import { LabelTransform } from '../'
+import { IssueReactorInput, IssueReactor } from './issue_reactor'
+import { issueLabelTransforms as presentationTeamTransforms } from '../../teams/presentation_team'
+
+/**
+ * Teams and other interested parties should add their label transform functions to this
+ * list.
+ *
+ * ORDER MATTERS.
+ *
+ * The functions are run in order-- left-to-right-- thus transforming the result of the previous
+ * transform.
+ */
+const labelTransforms: LabelTransform[] = [...presentationTeamTransforms]
+
+const RELEVANT_ACTIONS_MISSING_LABEL: IssueReactorInput['action'][] = [
+  'edited',
+  'refresh',
+  'opened',
+]
+
+export const addLabelReactor = new IssueReactor({
+  id: 'issueAddLabelReactor',
+
+  filter: ({ input: { action, issue } }) =>
+    issue.state === 'open' && RELEVANT_ACTIONS_MISSING_LABEL.includes(action),
+
+  async exec({ input: { issue, action }, log, githubApi }) {
+    log.info(`issue #${issue.number} [action=${action}]`, { action })
+    const labelNames = issue.labels.map(l => l.name)
+    let labels = [...labelNames]
+
+    labelTransforms.forEach(check => {
+      labels = check(labels)
+    })
+
+    const diff = labels.filter(label => !labelNames.includes(label))
+
+    if (diff.length > 0) {
+      await githubApi.setIssueLabels(issue.number, labels)
+    }
+
+    return {
+      issue: issue.number,
+      issueTitle: issue.title,
+    }
+  },
+})

--- a/src/reactors/issue/add_label_reactor.ts
+++ b/src/reactors/issue/add_label_reactor.ts
@@ -1,4 +1,4 @@
-import { LabelTransform } from '../'
+import { LabelTransform, performLabelTransform } from '../'
 import { IssueReactorInput, IssueReactor } from './issue_reactor'
 import { issueLabelTransforms as presentationTeamTransforms } from '../../teams/presentation_team'
 
@@ -27,17 +27,15 @@ export const addLabelReactor = new IssueReactor({
 
   async exec({ input: { issue, action }, log, githubApi }) {
     log.info(`issue #${issue.number} [action=${action}]`, { action })
-    const labelNames = issue.labels.map(l => l.name)
-    let labels = [...labelNames]
 
-    labelTransforms.forEach(check => {
-      labels = check(labels)
-    })
+    const existingLabels = issue.labels.map(label => label.name)
+    const transformedLabels = performLabelTransform(
+      existingLabels,
+      labelTransforms,
+    )
 
-    const diff = labels.filter(label => !labelNames.includes(label))
-
-    if (diff.length > 0) {
-      await githubApi.setIssueLabels(issue.number, labels)
+    if (transformedLabels) {
+      await githubApi.setIssueLabels(issue.number, transformedLabels)
     }
 
     return {

--- a/src/reactors/issue/add_label_reactor.ts
+++ b/src/reactors/issue/add_label_reactor.ts
@@ -35,7 +35,8 @@ export const addLabelReactor = new IssueReactor({
     )
 
     if (transformedLabels) {
-      await githubApi.setIssueLabels(issue.number, transformedLabels)
+      const { labels } = transformedLabels
+      await githubApi.setIssueLabels(issue.number, labels)
     }
 
     return {

--- a/src/reactors/issue/add_label_reactor.ts
+++ b/src/reactors/issue/add_label_reactor.ts
@@ -1,6 +1,6 @@
-import { LabelTransform, performLabelTransform } from '../'
-import { IssueReactorInput, IssueReactor } from './issue_reactor'
 import { issueLabelTransforms as presentationTeamTransforms } from '../../teams/presentation_team'
+import { LabelTransform, applyLabelTransforms } from '../apply_label_transforms'
+import { IssueReactorInput, IssueReactor } from './issue_reactor'
 
 /**
  * Teams and other interested parties should add their label transform functions to this
@@ -29,7 +29,7 @@ export const addLabelReactor = new IssueReactor({
     log.info(`issue #${issue.number} [action=${action}]`, { action })
 
     const existingLabels = issue.labels.map(label => label.name)
-    const transformedLabels = performLabelTransform(
+    const transformedLabels = applyLabelTransforms(
       existingLabels,
       labelTransforms,
     )

--- a/src/reactors/issue/index.ts
+++ b/src/reactors/issue/index.ts
@@ -1,3 +1,4 @@
 import { helloWorld } from './hello_world'
+import { addLabelReactor } from './add_label_reactor'
 
-export const issueReactors = [helloWorld]
+export const issueReactors = [helloWorld, addLabelReactor]

--- a/src/reactors/pr/add_label_reactor.ts
+++ b/src/reactors/pr/add_label_reactor.ts
@@ -1,6 +1,6 @@
-import { LabelTransform, performLabelTransform } from '../'
 import { RELEASE_BRANCH_RE } from '../../lib'
 import { prAddLabelTransforms as presentationTeamTransforms } from '../../teams/presentation_team'
+import { LabelTransform, applyLabelTransforms } from '../apply_label_transforms'
 import { ReactorInput, PrReactor } from './pr_reactor'
 
 /**
@@ -35,7 +35,7 @@ export const addLabelReactor = new PrReactor({
     log.info(`pr #${pr.number} [action=${action}]`, { action })
 
     const existingLabels = pr.labels.map(label => label.name)
-    const transformedLabels = performLabelTransform(
+    const transformedLabels = applyLabelTransforms(
       existingLabels,
       labelTransforms,
     )

--- a/src/reactors/pr/add_label_reactor.ts
+++ b/src/reactors/pr/add_label_reactor.ts
@@ -47,7 +47,7 @@ export const addLabelReactor = new PrReactor({
     const isBasedOnReleaseBranch = RELEASE_BRANCH_RE.test(pr.base.ref)
     const isBackport = labelNames.includes('backport')
 
-    if (isBasedOnReleaseBranch && diff && !isBackport) {
+    if (isBasedOnReleaseBranch && diff.length && !isBackport) {
       await githubApi.setPrLabels(pr.number, labels)
     }
 

--- a/src/reactors/pr/add_label_reactor.ts
+++ b/src/reactors/pr/add_label_reactor.ts
@@ -46,7 +46,8 @@ export const addLabelReactor = new PrReactor({
     const isBackport = existingLabels.includes('backport')
 
     if (transformedLabels && isBasedOnReleaseBranch && !isBackport) {
-      await githubApi.setPrLabels(pr.number, transformedLabels)
+      const { labels } = transformedLabels
+      await githubApi.setPrLabels(pr.number, labels)
     }
 
     return {

--- a/src/reactors/pr/add_label_reactor.ts
+++ b/src/reactors/pr/add_label_reactor.ts
@@ -34,11 +34,7 @@ export const addLabelReactor = new PrReactor({
   async exec({ input: { pr, action }, githubApi, log }) {
     log.info(`pr #${pr.number} [action=${action}]`, { action })
     const labelNames = pr.labels.map(label => label.name)
-    let labels = [...labelNames]
-
-    labelTransforms.forEach(check => {
-      labels = check(labels)
-    })
+    const labels = labelTransforms.reduce((acc, transform) => transform(acc), [...labelNames])
 
     const diff = labels.filter(label => !labelNames.includes(label))
 

--- a/src/reactors/pr/add_label_reactor.ts
+++ b/src/reactors/pr/add_label_reactor.ts
@@ -1,0 +1,63 @@
+import { LabelTransform } from '../'
+import { RELEASE_BRANCH_RE } from '../../lib'
+import { prAddLabelTransforms as presentationTeamTransforms } from '../../teams/presentation_team'
+import { ReactorInput, PrReactor } from './pr_reactor'
+
+/**
+ * Teams and other interested parties should add their label transform functions to this
+ * list.
+ *
+ * ORDER MATTERS.
+ *
+ * The functions are run in order-- left-to-right-- thus transforming the result of the previous
+ * transform.
+ */
+const labelTransforms: LabelTransform[] = [...presentationTeamTransforms]
+
+const RELEVANT_ACTIONS_MISSING_LABEL: ReactorInput['action'][] = [
+  'labeled',
+  'unlabeled',
+  'opened',
+  'synchronize',
+  'refresh',
+  'ready_for_review',
+]
+
+export const addLabelReactor = new PrReactor({
+  id: 'prAddLabelReactor',
+
+  filter: ({ input: { action, pr } }) =>
+    pr.state === 'open' &&
+    !pr.draft &&
+    RELEVANT_ACTIONS_MISSING_LABEL.includes(action),
+
+  async exec({ input: { pr, action }, githubApi, log }) {
+    log.info(`pr #${pr.number} [action=${action}]`, { action })
+    const labelNames = pr.labels.map(label => label.name)
+    let labels = [...labelNames]
+
+    labelTransforms.forEach(check => {
+      labels = check(labels)
+    })
+
+    const diff = labels.filter(label => !labelNames.includes(label))
+
+    // we must check these in exec() since they can change over time so we don't want
+    // to orphan a PR that became a backport PR or was retargetted away from master
+    const isBasedOnReleaseBranch = RELEASE_BRANCH_RE.test(pr.base.ref)
+    const isBackport = labelNames.includes('backport')
+
+    if (isBasedOnReleaseBranch && diff && !isBackport) {
+      await githubApi.setPrLabels(pr.number, labels)
+    }
+
+    return {
+      pr: pr.number,
+      prTitle: pr.title,
+      labelNames,
+      diff,
+      isBasedOnReleaseBranch,
+      isBackport,
+    }
+  },
+})

--- a/src/reactors/pr/index.ts
+++ b/src/reactors/pr/index.ts
@@ -5,6 +5,8 @@ import { ciNotRequired } from './ci_not_required'
 import { badCommits } from './bad_commits'
 import { backportReminder } from './backport_reminder'
 import { communityPr } from './community_pr'
+import { addLabelReactor } from './add_label_reactor'
+import { missingLabelReactor } from './missing_label_reactor'
 
 export const prReactors = [
   outdated,
@@ -14,4 +16,6 @@ export const prReactors = [
   badCommits,
   backportReminder,
   communityPr,
+  addLabelReactor,
+  missingLabelReactor,
 ]

--- a/src/reactors/pr/missing_label_reactor.ts
+++ b/src/reactors/pr/missing_label_reactor.ts
@@ -56,7 +56,7 @@ export const missingLabelReactor = new PrReactor({
       await githubApi.setCommitStatus(pr.head.sha, {
         context: 'prbot:required labels',
         description: `${
-          added.length > 1 ? 'Several labels are' : 'Label is '
+          added.length > 1 ? 'Several labels are' : 'Label is'
         } missing: ${added.join(', ')}`,
         state: 'failure',
       })

--- a/src/reactors/pr/missing_label_reactor.ts
+++ b/src/reactors/pr/missing_label_reactor.ts
@@ -1,0 +1,75 @@
+import { LabelTransform } from '../'
+import { RELEASE_BRANCH_RE, InvalidLabelLog } from '../../lib'
+import { prMissingLabelTransforms as presentationTeamTransforms } from '../../teams/presentation_team'
+import { ReactorInput, PrReactor } from './pr_reactor'
+
+/**
+ * Teams and other interested parties should add their label transform functions to this
+ * list.
+ *
+ * ORDER MATTERS.
+ *
+ * The functions are run in order-- left-to-right-- thus transforming the result of the previous
+ * transform.
+ */
+const labelTransforms: LabelTransform[] = [...presentationTeamTransforms]
+
+const RELEVANT_ACTIONS_MISSING_LABEL: ReactorInput['action'][] = [
+  'labeled',
+  'unlabeled',
+  'opened',
+  'synchronize',
+  'refresh',
+  'ready_for_review',
+]
+
+export const missingLabelReactor = new PrReactor({
+  id: 'prMissingLabelReactor',
+
+  filter: ({ input: { action, pr } }) =>
+    pr.state === 'open' &&
+    !pr.draft &&
+    RELEVANT_ACTIONS_MISSING_LABEL.includes(action),
+
+  async exec({ input: { pr, action }, githubApi, es, log }) {
+    log.info(`issue #${pr.number} [action=${action}]`, { action })
+    const labelNames = pr.labels.map(label => label.name)
+    let labels = [...labelNames]
+
+    labelTransforms.forEach(check => {
+      labels = check(labels)
+    })
+
+    const diff = labels.filter(label => !labelNames.includes(label))
+
+    // we must check these in exec() since they can change over time so we don't want
+    // to orphan a PR that became a backport PR or was retargetted away from master
+    const isBasedOnReleaseBranch = RELEASE_BRANCH_RE.test(pr.base.ref)
+    const isBackport = labelNames.includes('backport')
+
+    if (isBasedOnReleaseBranch && diff.length > 0 && !isBackport) {
+      await new InvalidLabelLog(es, log).add(pr.number)
+      await githubApi.setCommitStatus(pr.head.sha, {
+        context: 'prbot:required labels',
+        description: `${
+          diff.length > 1 ? 'Several labels are' : 'Label is '
+        } missing: ${diff.join(', ')}`,
+        state: 'failure',
+      })
+    } else {
+      await githubApi.setCommitStatus(pr.head.sha, {
+        context: 'prbot:required labels',
+        state: 'success',
+      })
+    }
+
+    return {
+      pr: pr.number,
+      prTitle: pr.title,
+      labelNames,
+      diff,
+      isBasedOnReleaseBranch,
+      isBackport,
+    }
+  },
+})

--- a/src/reactors/pr/missing_label_reactor.ts
+++ b/src/reactors/pr/missing_label_reactor.ts
@@ -45,13 +45,19 @@ export const missingLabelReactor = new PrReactor({
     const isBasedOnReleaseBranch = RELEASE_BRANCH_RE.test(pr.base.ref)
     const isBackport = existingLabels.includes('backport')
 
-    if (transformedLabels && isBasedOnReleaseBranch && !isBackport) {
+    if (
+      transformedLabels &&
+      transformedLabels.added.length > 0 &&
+      isBasedOnReleaseBranch &&
+      !isBackport
+    ) {
+      const { added } = transformedLabels
       await new InvalidLabelLog(es, log).add(pr.number)
       await githubApi.setCommitStatus(pr.head.sha, {
         context: 'prbot:required labels',
         description: `${
-          transformedLabels.length > 1 ? 'Several labels are' : 'Label is '
-        } missing: ${transformedLabels.join(', ')}`,
+          added.length > 1 ? 'Several labels are' : 'Label is '
+        } missing: ${added.join(', ')}`,
         state: 'failure',
       })
     } else {

--- a/src/reactors/pr/missing_label_reactor.ts
+++ b/src/reactors/pr/missing_label_reactor.ts
@@ -1,6 +1,6 @@
-import { LabelTransform, performLabelTransform } from '../'
 import { RELEASE_BRANCH_RE, InvalidLabelLog } from '../../lib'
 import { prMissingLabelTransforms as presentationTeamTransforms } from '../../teams/presentation_team'
+import { LabelTransform, applyLabelTransforms } from '../apply_label_transforms'
 import { ReactorInput, PrReactor } from './pr_reactor'
 
 /**
@@ -35,7 +35,7 @@ export const missingLabelReactor = new PrReactor({
     log.info(`issue #${pr.number} [action=${action}]`, { action })
 
     const existingLabels = pr.labels.map(label => label.name)
-    const transformedLabels = performLabelTransform(
+    const transformedLabels = applyLabelTransforms(
       existingLabels,
       labelTransforms,
     )

--- a/src/routes/fixup_invalid_labels.ts
+++ b/src/routes/fixup_invalid_labels.ts
@@ -3,7 +3,11 @@ import { Route } from '@spalger/micro-plus'
 import { prReactors, runReactors } from '../reactors'
 import { getRequestLogger, InvalidLabelLog } from '../lib'
 
-const LABEL_REACTORS = ['releaseNoteLabels', 'releaseVersionLabels']
+const LABEL_REACTORS = [
+  'releaseNoteLabels',
+  'releaseVersionLabels',
+  'prMissingLabelReactor',
+]
 
 export const fixupInvalidLabelsRoute = new Route(
   'GET',

--- a/src/teams/presentation_team.ts
+++ b/src/teams/presentation_team.ts
@@ -1,0 +1,52 @@
+import { LabelTransform } from '../reactors'
+
+const LABEL_PRESENTATION_TEAM = 'Team:Presentation'
+const LABEL_CANVAS = 'Feature:Canvas'
+const LABEL_DASHBOARD = 'Feature:Dashboard'
+const LABEL_IMPACT_PREFIX = 'impact:'
+const LABEL_IMPACT_NEEDS_ASSESSMENT = 'impact:needs-assessment'
+const LABEL_LOE_PREFIX = 'loe:'
+const LABEL_LOE_NEEDS_RESEARCH = 'loe:needs-research'
+
+const hasCanvasOrDashboardLabel = (labels: string[]) =>
+  labels.some(label => label === LABEL_CANVAS || label === LABEL_DASHBOARD)
+
+const shouldAddPresentationTeamLabel: LabelTransform = labels =>
+  hasCanvasOrDashboardLabel(labels) &&
+  !labels.some(label => label === LABEL_PRESENTATION_TEAM)
+    ? [...labels, LABEL_PRESENTATION_TEAM]
+    : labels
+
+const shouldAddImpactLabel: LabelTransform = labels =>
+  hasCanvasOrDashboardLabel(labels) &&
+  !labels.some(label => label.startsWith(LABEL_IMPACT_PREFIX))
+    ? [...labels, LABEL_IMPACT_NEEDS_ASSESSMENT]
+    : labels
+
+const needsImpactLabel: LabelTransform = labels =>
+  hasCanvasOrDashboardLabel(labels) &&
+  !labels.some(label => label.startsWith(LABEL_IMPACT_PREFIX))
+    ? [...labels, LABEL_IMPACT_PREFIX + '*']
+    : labels
+
+const shouldAddLOELabel: LabelTransform = labels =>
+  hasCanvasOrDashboardLabel(labels) &&
+  !labels.some(label => label.startsWith(LABEL_LOE_PREFIX))
+    ? [...labels, LABEL_LOE_NEEDS_RESEARCH]
+    : labels
+
+const needsLOELabel: LabelTransform = labels =>
+  hasCanvasOrDashboardLabel(labels) &&
+  !labels.some(label => label.startsWith(LABEL_LOE_PREFIX))
+    ? [...labels, LABEL_LOE_PREFIX + '*']
+    : labels
+
+export const issueLabelTransforms = [
+  shouldAddPresentationTeamLabel,
+  shouldAddImpactLabel,
+  shouldAddLOELabel,
+]
+
+export const prMissingLabelTransforms = [needsImpactLabel, needsLOELabel]
+
+export const prAddLabelTransforms = [shouldAddPresentationTeamLabel]


### PR DESCRIPTION
This PR adds a space for team-specific code, as well as three new Reactors:

- `issueAddLabelReactor`: Adds labels that are missing from a given issue;
- `prAddLabelReactor`: Adds labels that are missing from a given pr;
- `prMissingLabelReactor`: Fails a PR if it is missing a label

<img width="608" alt="Screen Shot 2021-03-04 at 11 34 54 PM" src="https://user-images.githubusercontent.com/297604/110071992-aa18d600-7d42-11eb-9970-6152b27c5b9a.png">
<img width="856" alt="Screen Shot 2021-03-04 at 11 45 44 PM" src="https://user-images.githubusercontent.com/297604/110072681-c49f7f00-7d43-11eb-8a2d-b53fc52c146b.png">
