### PR TITLE
Mention `auto-backport` label in reminder message

### DIFF
--- a/src/lib/backport_reminder.ts
+++ b/src/lib/backport_reminder.ts
@@ -30,7 +30,8 @@ const createBackportReminderComment = (
   if (pendingPrs === 0) {
     return (
       'Friendly reminder: Looks like this PR hasn’t been backported yet.\n' +
-      `To create backports run \`node scripts/backport --pr ${prNumber}\` or prevent reminders by adding the \`backport:skip\` label.`
+      `To create automatically backports add the label \`auto-backport\` or prevent reminders by adding the \`backport:skip\` label.\n` +
+      `You can also create backports manually by running \`node scripts/backport --pr ${prNumber}\` locally`
     )
   }
 


### PR DESCRIPTION
We currently don't mention the `auto-backport` label in the reminder message. We should.

<img width="862" alt="image" src="https://user-images.githubusercontent.com/209966/171598453-5bc1101e-6893-4675-8e05-e8a09e9b2800.png">
